### PR TITLE
fix(heartbeat): distinguish worker-stuck from process-stuck; only mention daemon.log if it exists (closes #9)

### DIFF
--- a/scripts/detectors/marketplace-refresh.py
+++ b/scripts/detectors/marketplace-refresh.py
@@ -217,10 +217,12 @@ def _emit_daemon_stale_drift_if_needed() -> None:
     out = dedupe.emit_once(
         seen,
         key,
-        f"[marketplace-refresh] daemon has not refreshed global marketplaces in "
-        f"~{age // 60} min (cadence {cadence}s) — daemon may be stuck. "
-        f"Inspect: ~/.claude/janitor-global-state/daemon.log. "
-        f"Restart: kill $(cat ~/.claude/janitor-global-state/daemon.pid).",
+        gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=age,
+            cadence_s=cadence,
+        ),
     )
     if out is not None:
         print(out)

--- a/scripts/detectors/user-plugins-update.py
+++ b/scripts/detectors/user-plugins-update.py
@@ -62,10 +62,12 @@ def main() -> int:
     out = dedupe.emit_once(
         seen,
         key,
-        f"[user-plugins-update] daemon has not swept user-scope plugins in "
-        f"~{age // 60} min (cadence {cadence}s) — daemon may be stuck. "
-        f"Inspect: ~/.claude/janitor-global-state/daemon.log. "
-        f"Restart: kill $(cat ~/.claude/janitor-global-state/daemon.pid).",
+        gs.build_worker_stale_message(
+            worker_tag="user-plugins-update",
+            worker_action="swept user-scope plugins",
+            age_s=age,
+            cadence_s=cadence,
+        ),
     )
     if out is not None:
         print(out)

--- a/scripts/lib/global_state.py
+++ b/scripts/lib/global_state.py
@@ -161,6 +161,81 @@ def daemon_is_alive(max_silence_s: int = DEFAULT_DAEMON_STALE_SECONDS) -> bool:
     return (int(time.time()) - hb) <= max_silence_s
 
 
+# ---------- worker-staleness reporting ------------------------------------
+
+def _daemon_log_path() -> Path:
+    """Path the daemon writes its log to (when log rotation is enabled).
+
+    Currently the daemon doesn't open a real log file — only the per-worker
+    rotating logs live under `state_dir()/<worker-name>.log`. Issue #9: the
+    detector messages used to recommend `Inspect: <this path>` unconditionally,
+    sending users at a file that has never existed. Now the message-builders
+    below check `path.exists()` before referencing it."""
+    return global_state_dir() / "daemon.log"
+
+
+def build_worker_stale_message(
+    *,
+    worker_tag: str,
+    worker_action: str,
+    age_s: int,
+    cadence_s: int,
+) -> str:
+    """Build the user-facing 'worker is stale' heartbeat message.
+
+    Issue #9: the original messages said "daemon may be stuck" and recommended
+    inspecting `~/.claude/janitor-global-state/daemon.log` even when the
+    daemon **process** was healthy (just one of its workers had wedged) and
+    the log file had never existed. This builder distinguishes three cases:
+
+    1. **Daemon process dead / heartbeat stale** → the daemon itself stopped.
+       Recommend restart only (no point inspecting a log if there's no
+       process to dump state).
+    2. **Daemon process alive, worker wedged** → the worker subroutine hung
+       inside an otherwise-healthy daemon. Make that distinction explicit so
+       the user doesn't go looking at the daemon process when the process
+       is fine. Restart still works (re-initialises every worker).
+    3. **Log file actually exists** → only then mention "Inspect: <path>".
+
+    `worker_tag` is the bracketed label (e.g. `"marketplace-refresh"`).
+    `worker_action` is the verb phrase the worker performs in English
+    (e.g. `"refreshed global marketplaces"`)."""
+    pid = daemon_pid()
+    hb = read_heartbeat()
+    now = int(time.time())
+    hb_age_s = (now - hb) if hb > 0 else -1
+    daemon_alive = (
+        pid is not None
+        and _process_exists(pid)
+        and 0 <= hb_age_s <= DEFAULT_DAEMON_STALE_SECONDS
+    )
+
+    age_min = age_s // 60
+    head = (
+        f"[{worker_tag}] worker has not {worker_action} in "
+        f"~{age_min} min (cadence {cadence_s}s) — "
+    )
+    if daemon_alive:
+        diagnosis = (
+            f"the daemon process is alive (PID {pid}, last heartbeat "
+            f"{hb_age_s}s ago) but the {worker_tag} worker has likely wedged. "
+        )
+    else:
+        diagnosis = (
+            "the daemon process itself is not responding "
+            "(no recent heartbeat) — daemon may have crashed or hung. "
+        )
+
+    # Only point at the daemon log if it actually exists on disk.
+    inspect_clause = ""
+    log_path = _daemon_log_path()
+    if log_path.exists():
+        inspect_clause = f"Inspect: {log_path}. "
+
+    restart_clause = "Restart: kill $(cat ~/.claude/janitor-global-state/daemon.pid)."
+    return head + diagnosis + inspect_clause + restart_clause
+
+
 # ---------- singleton flock ----------------------------------------------
 
 def acquire_singleton_flock() -> Optional[int]:

--- a/tests/test_worker_stale_message.py
+++ b/tests/test_worker_stale_message.py
@@ -1,0 +1,266 @@
+"""Tests for `build_worker_stale_message` (issue #9 fix).
+
+The original heartbeat message for both `marketplace-refresh` and
+`user-plugins-update` said "daemon may be stuck" even when the daemon
+process was healthy (only a worker subroutine had wedged) AND recommended
+inspecting `~/.claude/janitor-global-state/daemon.log` — a file the daemon
+has never written. This forced users to investigate the wrong layer and
+to chase a non-existent log.
+
+`build_worker_stale_message` distinguishes the three legitimate states:
+
+* daemon process alive + heartbeat fresh → "worker has wedged" wording
+  AND PID + heartbeat-age context (so the user can verify against `ps`)
+* daemon process dead or heartbeat stale → "daemon process is not
+  responding" wording
+* `daemon.log` only mentioned when it actually exists on disk
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "scripts"))
+sys.path.insert(0, str(_PROJECT_ROOT / "scripts" / "lib"))
+
+
+@pytest.fixture
+def state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated global state dir per test — same convention as test_global_state."""
+    d = tmp_path / "janitor-global-state"
+    monkeypatch.setenv("JANITOR_GLOBAL_STATE_DIR", str(d))
+    for mod in ("global_state",):
+        if mod in sys.modules:
+            del sys.modules[mod]
+    return d
+
+
+def _gs():
+    import global_state  # type: ignore[import-not-found]
+    return global_state
+
+
+def _arm_alive_daemon(gs, hb_age_s: int = 5) -> None:
+    """Write daemon.pid (using THIS pytest PID — guaranteed alive) and a
+    fresh daemon.heartbeat.ts that's `hb_age_s` seconds old."""
+    gs.init_global_state()
+    gs.write_daemon_pid(os.getpid())
+    gs.write_heartbeat(int(time.time()) - hb_age_s)
+
+
+def _arm_dead_daemon(gs) -> None:
+    """Write daemon.pid pointing at a definitely-not-running PID."""
+    gs.init_global_state()
+    # PID 0 is sentinel for swapper on Unix — kill(0, 0) raises ESRCH for
+    # any unprivileged user. Combined with daemon_pid()'s `not raw.isdigit()`
+    # check we'd have to bypass the helper; instead use an absurdly high PID
+    # that cannot belong to anything on a fresh test sandbox.
+    gs.write_daemon_pid(2**31 - 1)
+    gs.write_heartbeat(int(time.time()))  # heartbeat fresh but PID dead
+
+
+# ─── daemon alive + worker stuck → "worker has wedged" wording ───────────
+
+
+class TestDaemonAliveWorkerWedged:
+    """When the daemon process is healthy but a worker is stale, the
+    message must NOT say 'daemon may be stuck' — it must distinguish the
+    layers so the user doesn't go check the wrong process."""
+
+    def test_alive_daemon_message_says_daemon_is_alive(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs, hb_age_s=5)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "daemon process is alive" in msg, msg
+        assert "daemon may be stuck" not in msg, msg
+
+    def test_alive_daemon_message_includes_pid(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs, hb_age_s=5)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert f"PID {os.getpid()}" in msg, msg
+
+    def test_alive_daemon_message_includes_heartbeat_age(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs, hb_age_s=42)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "last heartbeat" in msg, msg
+        # Age can be 42s or 43s depending on test-runtime slop; check the band.
+        assert ("42s ago" in msg) or ("43s ago" in msg), msg
+
+    def test_alive_daemon_message_says_worker_wedged(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "marketplace-refresh worker has likely wedged" in msg, msg
+
+
+# ─── daemon dead → "daemon process is not responding" wording ────────────
+
+
+class TestDaemonDeadOrStale:
+    """When the daemon process itself is dead, the message must SAY so
+    (not blame the worker)."""
+
+    def test_dead_daemon_message_says_process_not_responding(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_dead_daemon(gs)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "daemon process itself is not responding" in msg, msg
+        assert "daemon process is alive" not in msg, msg
+
+    def test_no_pid_file_treated_as_dead_daemon(self, state_dir: Path) -> None:
+        """No pid file at all → message uses the dead-daemon wording."""
+        gs = _gs()
+        gs.init_global_state()  # state dir exists but no daemon.pid written
+        msg = gs.build_worker_stale_message(
+            worker_tag="user-plugins-update",
+            worker_action="swept user-scope plugins",
+            age_s=8000,
+            cadence_s=3600,
+        )
+        assert "daemon process itself is not responding" in msg, msg
+
+    def test_stale_heartbeat_treated_as_dead_daemon(self, state_dir: Path) -> None:
+        """Even with a live PID, a heartbeat older than DEFAULT_DAEMON_STALE_SECONDS
+        means the daemon is wedged at the process level → dead-daemon wording."""
+        gs = _gs()
+        gs.init_global_state()
+        gs.write_daemon_pid(os.getpid())
+        # Set heartbeat 1 second past the staleness window (default 1800s).
+        gs.write_heartbeat(int(time.time()) - (gs.DEFAULT_DAEMON_STALE_SECONDS + 1))
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "daemon process itself is not responding" in msg, msg
+
+
+# ─── daemon.log conditional reference ────────────────────────────────────
+
+
+class TestDaemonLogReference:
+    """The 'Inspect: <path>' clause must only appear when the log exists."""
+
+    def test_no_log_file_no_inspect_clause(self, state_dir: Path) -> None:
+        """The repro: daemon.log doesn't exist (the common case today)."""
+        gs = _gs()
+        _arm_alive_daemon(gs)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "Inspect:" not in msg, msg
+        assert "daemon.log" not in msg, msg
+
+    def test_log_file_exists_inspect_clause_appears(self, state_dir: Path) -> None:
+        """When the daemon DOES write a log, the inspect-clause comes back."""
+        gs = _gs()
+        _arm_alive_daemon(gs)
+        log_path = state_dir / "daemon.log"
+        log_path.write_text("some log line\n", encoding="utf-8")
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert f"Inspect: {log_path}" in msg, msg
+
+
+# ─── message-shape invariants ────────────────────────────────────────────
+
+
+class TestMessageShape:
+    """Per-call invariants that must hold regardless of daemon state."""
+
+    def test_worker_tag_appears_in_brackets(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert msg.startswith("[marketplace-refresh]"), msg
+
+    def test_worker_action_appears(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "refreshed global marketplaces" in msg, msg
+
+    def test_restart_clause_always_present(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "Restart: kill" in msg, msg
+        assert "daemon.pid" in msg, msg
+
+    def test_age_converted_to_minutes(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,  # 43 min 20 s → ~43 min
+            cadence_s=1200,
+        )
+        assert "~43 min" in msg, msg
+
+    def test_cadence_appears(self, state_dir: Path) -> None:
+        gs = _gs()
+        _arm_alive_daemon(gs)
+        msg = gs.build_worker_stale_message(
+            worker_tag="marketplace-refresh",
+            worker_action="refreshed global marketplaces",
+            age_s=2600,
+            cadence_s=1200,
+        )
+        assert "cadence 1200s" in msg, msg


### PR DESCRIPTION
## Summary

Closes #9.

Both the marketplace-refresh and user-plugins-update heartbeat detectors used to emit:

```
[<worker>] daemon has not <verb> in ~N min (cadence Ns) — daemon may be stuck.
Inspect: ~/.claude/janitor-global-state/daemon.log.
Restart: kill $(cat ~/.claude/janitor-global-state/daemon.pid).
```

Two UX bugs in that message:

1. **\"daemon may be stuck\" implies the process is dead.** In the common case the daemon **process** is healthy (heartbeat fresh, `kill -0` succeeds) and it's just one of its worker subroutines that wedged. Users go check the daemon, see it alive, conclude the heartbeat is wrong — but the verdict is correct; only the wording points at the wrong layer.
2. **\"Inspect: ~/.claude/janitor-global-state/daemon.log\" — that file is never written.** `lsof -p <daemon-pid>` shows the daemon only holds `daemon.flock`; no log fd exists. The recommendation sends users at a path that has never existed.

## Fix

New helper in `scripts/lib/global_state.py`: `build_worker_stale_message(*, worker_tag, worker_action, age_s, cadence_s)`.

Branches on existing `daemon_pid()` + `read_heartbeat()` + `_process_exists()`:

| Daemon state | Message wording |
|---|---|
| pid alive **and** heartbeat fresh (≤ `DEFAULT_DAEMON_STALE_SECONDS`) | `\"the daemon process is alive (PID <pid>, last heartbeat <Δs>s ago) but the <worker> worker has likely wedged.\"` |
| pid missing / dead **or** heartbeat stale | `\"the daemon process itself is not responding (no recent heartbeat) — daemon may have crashed or hung.\"` |

The `\"Inspect: <daemon.log>\"` clause is gated behind `os.path.exists(path)` — only appears when the log actually exists. Restart clause is always present (restarting the daemon re-initialises every worker, fixes both wedge classes).

Both detectors (`scripts/detectors/marketplace-refresh.py`, `scripts/detectors/user-plugins-update.py`) now call the shared builder instead of hand-formatting the warning.

## Test plan

- [x] `tests/test_worker_stale_message.py` — 14 new two-sided assertions:
  - `TestDaemonAliveWorkerWedged` (4) — alive daemon path: message contains \"daemon process is alive\", PID, heartbeat-age, \"<worker> has likely wedged\"; explicitly NOT \"daemon may be stuck\".
  - `TestDaemonDeadOrStale` (3) — dead-PID / no-pid-file / stale-heartbeat all produce the \"daemon process itself is not responding\" wording.
  - `TestDaemonLogReference` (2) — Inspect clause absent when log file missing; appears when log file exists.
  - `TestMessageShape` (5) — worker tag in brackets, worker action verbatim, restart clause always present, age rendered as minutes, cadence rendered with `s` suffix.
- [x] 225 existing tests still pass (4 pre-existing sentinel-test collection errors are PyYAML missing from test deps; not introduced by this change).
- [x] Fixture pattern matches `tests/test_global_state.py`: per-test `JANITOR_GLOBAL_STATE_DIR` isolation, running pytest PID for guaranteed-alive PID, `2**31-1` for guaranteed-dead PID.